### PR TITLE
Adds `preact` support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exome",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "exome",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^14.14.41",
@@ -30,9 +30,13 @@
         "uvu": "^0.5.1"
       },
       "peerDependencies": {
+        "preact": ">= 10.0.0",
         "react": ">= 16.8.0"
       },
       "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        },
         "react": {
           "optional": true
         }
@@ -2594,6 +2598,17 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.5.13",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.13.tgz",
+      "integrity": "sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {
@@ -5430,6 +5445,13 @@
           "dev": true
         }
       }
+    },
+    "preact": {
+      "version": "10.5.13",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.13.tgz",
+      "integrity": "sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==",
+      "optional": true,
+      "peer": true
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exome",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Proxy based store manager for deeply nested states",
   "main": "exome.js",
   "module": "exome.esm.js",
@@ -22,10 +22,12 @@
   "keywords": [
     "store",
     "state",
+    "state-manager",
     "proxy",
     "deep",
     "nested",
-    "react"
+    "react",
+    "preact"
   ],
   "author": "Marcis <marcisbergmanis@gmail.com>",
   "license": "MIT",
@@ -55,10 +57,14 @@
     "uvu": "^0.5.1"
   },
   "peerDependencies": {
+    "preact": ">= 10.0.0",
     "react": ">= 16.8.0"
   },
   "peerDependenciesMeta": {
     "react": {
+      "optional": true
+    },
+    "preact": {
       "optional": true
     }
   },
@@ -74,6 +80,10 @@
     "./react": {
       "require": "./react.js",
       "import": "./react.esm.js"
+    },
+    "./preact": {
+      "require": "./preact.js",
+      "import": "./preact.esm.js"
     }
   }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -22,6 +22,7 @@ import { build } from 'esbuild'
     build({
       entryPoints: [
         'src/react.ts',
+        'src/preact.ts',
         'src/devtools.ts'
       ],
       outdir: 'dist',
@@ -35,6 +36,7 @@ import { build } from 'esbuild'
       sourcemap: 'external',
       external: [
         'react',
+        'preact',
         'exome'
       ],
       logLevel: 'info'

--- a/src/preact.ts
+++ b/src/preact.ts
@@ -1,0 +1,58 @@
+import { Exome, addMiddleware, Middleware, getExomeId, updateMap } from 'exome'
+import { useLayoutEffect, useEffect, useReducer } from 'preact/hooks'
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined'
+  ? useLayoutEffect
+  : useEffect
+
+const preactMiddleware: Middleware = (instance) => {
+  return () => {
+    const id = getExomeId(instance)
+    const renderers = updateMap[id] ?? []
+
+    updateMap[id] = []
+
+    renderers.forEach((renderer) => renderer())
+  }
+}
+
+addMiddleware(preactMiddleware)
+
+export function useStore<T extends Exome>(store: T): Readonly<T> {
+  const [changed, render] = useReducer((n: boolean) => !n, true)
+  const id = getExomeId(store)
+
+  useIsomorphicLayoutEffect(
+    () => {
+      if (!updateMap[id]) {
+        updateMap[id] = []
+      }
+
+      const queue = updateMap[id]!
+      const renderHandler: any = render
+
+      queue.push(renderHandler)
+
+      return () => {
+        if (queue === updateMap[id]!) {
+          const index = queue.indexOf(renderHandler)
+
+          if (index === -1) {
+            return
+          }
+
+          queue.splice(index, 1)
+        }
+      }
+    },
+    [id, changed]
+  )
+
+  if (!id) {
+    throw new Error(
+      '"useStore" encountered store that is not an instance of "Exome"'
+    )
+  }
+
+  return store
+}


### PR DESCRIPTION
Example usage is basically the same as react, only difference is the import path.

```ts
import { useStore } from 'exome/preact'
```