### PR TITLE
Adds `rxjs` observable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+### Features
+* Adds RXJS Observable support.
+
 ## 1.1.0
 
 ### Features

--- a/benchmark/react/counter/index.ts
+++ b/benchmark/react/counter/index.ts
@@ -1,6 +1,8 @@
 import Benchmark, { Suite, Options } from 'benchmark'
 import ReactDOM from 'react-dom';
 
+// import useState from './use-state';
+// import useReducer from './use-reducer';
 import exome from './exome';
 import redux from './redux';
 import reduxToolkit from './redux-toolkit';
@@ -40,6 +42,11 @@ function configTest(renderer: (target: HTMLElement) => void): Options {
 
 // add tests
 suite
+  // React baseline for performance
+  // .add('useState', configTest(useState))
+  // .add('useReducer', configTest(useReducer))
+
+  // Benchmark subjects
   .add('Exome', configTest(exome))
   .add('Redux', configTest(redux))
   .add('Redux Toolkit', configTest(reduxToolkit))

--- a/benchmark/react/counter/use-reducer.tsx
+++ b/benchmark/react/counter/use-reducer.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+
+function increment(value: number) {
+  return value + 1;
+}
+
+function App() {
+  const [count, incrementCount] = React.useReducer(increment, 0);
+
+  return (
+    <h1 onClick={incrementCount}>{count}</h1>
+  )
+}
+
+let key = 0;
+
+export default function (target: HTMLElement) {
+  ReactDom.render(<App key={key++} />, target)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exome",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "exome",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.6.1",
@@ -29,6 +29,7 @@
         "proxyquire": "^2.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "rxjs": "^7.0.0",
         "sinon": "^14.0.0",
         "typescript": "^4.7.4",
         "uvu": "^0.5.6",
@@ -38,6 +39,7 @@
         "lit": ">= 2.0.0",
         "preact": ">= 10.1.0",
         "react": ">= 16.8.0",
+        "rxjs": ">= 6.0.0",
         "vue": ">= 3.0.0"
       },
       "peerDependenciesMeta": {
@@ -48,6 +50,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "rxjs": {
           "optional": true
         },
         "vue": {
@@ -3451,6 +3456,21 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -6487,6 +6507,23 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
       }
     },
     "sade": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exome",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Proxy based store manager for deeply nested states",
   "main": "exome.js",
   "module": "exome.esm.js",
@@ -62,13 +62,15 @@
     "sinon": "^14.0.0",
     "typescript": "^4.7.4",
     "uvu": "^0.5.6",
-    "vue": "^3.2.37"
+    "vue": "^3.2.37",
+    "rxjs": "^7.0.0"
   },
   "peerDependencies": {
     "lit": ">= 2.0.0",
     "preact": ">= 10.1.0",
     "react": ">= 16.8.0",
-    "vue": ">= 3.0.0"
+    "vue": ">= 3.0.0",
+    "rxjs": ">= 6.0.0"
   },
   "peerDependenciesMeta": {
     "lit": {
@@ -81,6 +83,9 @@
       "optional": true
     },
     "vue": {
+      "optional": true
+    },
+    "rxjs": {
       "optional": true
     }
   },
@@ -112,6 +117,10 @@
     "./lit": {
       "require": "./lit.js",
       "import": "./lit.esm.js"
+    },
+    "./rxjs": {
+      "require": "./rxjs.js",
+      "import": "./rxjs.esm.js"
     }
   }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -26,6 +26,7 @@ import { build } from 'esbuild'
         'src/preact.ts',
         'src/vue.ts',
         'src/lit.ts',
+        'src/rxjs.ts',
         'src/devtools.ts'
       ],
       outdir: 'dist',
@@ -42,6 +43,7 @@ import { build } from 'esbuild'
         'preact',
         'vue',
         'lit',
+        'rxjs',
         'exome'
       ],
       logLevel: 'info'

--- a/src/rxjs.ts
+++ b/src/rxjs.ts
@@ -1,0 +1,12 @@
+import { Exome } from 'exome'
+import { subscribe } from './subscribe'
+import { Observable } from 'rxjs'
+
+export function observableFromExome<T extends Exome = Exome>(
+  store: T
+): Observable<T> {
+  return new Observable<T>((subscriber) => {
+    subscribe(store, (value) => subscriber.next(value))
+    subscriber.next(store)
+  })
+}


### PR DESCRIPTION
Usage:

```ts
import { observableFromExome } from 'exome/rxjs';
import { distinctUntilChanged, map } from 'rxjs/operators';

class CounterStore extends Exome {
  public count = 0;

  public increment() {
    this.count += 1;
  }
}

const countStore = new CounterStore();

// This CounterStore is an Observable now via `counter$` variable!
const counter$ = observableFromExome(countStore);

document.querySelector('#app').innerHTML = `<button id="counter"></button>`;

const button = document.querySelector<HTMLButtonElement>('#counter')!;
button.addEventListener('click', countStore.increment);

// We can pipe, map and do everything we do with Observables.
counter$
  .pipe(
    map((store) => store.count),
    distinctUntilChanged()
  )
  .subscribe((value) => {
    // Finally update UI with updated value!
    button.innerHTML = String(value);
  });
```

Live example here: https://stackblitz.com/edit/vitejs-vite-yifgei?file=src%2Fmain.ts