### PR TITLE
fix: typo in Angular integration README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ import { counter } from "./store/counter.ts"
   `,
 })
 export class App {
-  public count = useStore(store, (s) => s.count);
+  public count = useStore(counter, (s) => s.count);
   public increment() {
-    store.increment();
+    counter.increment();
   }
 }
 ```


### PR DESCRIPTION
Just a small fix, this example is importing `counter` here.